### PR TITLE
fix path to default player sheet for pf2e

### DIFF
--- a/mappings/pf2e/standard/latest/player.js
+++ b/mappings/pf2e/standard/latest/player.js
@@ -30,7 +30,7 @@ class MappingClass extends baseMapping {
 
         // Set the PDF files to use - MIND that the order of the files is important!
         this.pdfFiles.push({
-            pdfUrl: '/modules/sheet-export/mappings/pf2e/remastered/latest/pf2e-remastered.pdf',
+            pdfUrl: '/modules/sheet-export/mappings/pf2e/standard/latest/pf2e-remastered.pdf',
             nameDownload: `${this.actor.name ?? "character"}.pdf`,
             name: "pf2e-remastered.pdf",
         });


### PR DESCRIPTION
default path for pf2e was still pointing to previous remaster path